### PR TITLE
Bumped dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,9 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.10.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.1.0"),
-        .package(url: "https://github.com/vapor/jwt-kit.git", branch: "main"),
-        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.0.0-beta.1"),
-        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.0.0-beta.1")
+        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.13.1"),
+        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.10.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.1.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "2.1.0" ..< "4.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.13.1"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0")


### PR DESCRIPTION
The primary motivation was that I could not use `.package(url: "https://github.com/m-barthelemy/AcmeSwift.git", from: "1.0.0-beta2")` because jwt-kit was pinned at main.

`swift-crypto` was bumped because this forced a downgrade in my project and https://github.com/apple/swift-crypto/releases/tag/3.0.0 recommends `"1.0.0" ..< "4.0.0"` as the version range.

The two other bumps are just moving away from beta-versions and onto the current latest.