### PR TITLE
Singleton EventLoopGroupProvider

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["AcmeSwift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.10.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "2.1.0" ..< "4.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.13.1"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.2.0"),

--- a/Sources/AcmeSwift/APIs/AcmeSwift.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift.swift
@@ -24,7 +24,7 @@ public class AcmeSwift {
     private let logger: Logger
     private let decoder: JSONDecoder
     
-    public init(client: HTTPClient = .init(eventLoopGroupProvider: .createNew), acmeEndpoint: AcmeEndpoint = .letsEncrypt, logger: Logger = Logger.init(label: "AcmeSwift")) async throws {
+    public init(client: HTTPClient = .init(eventLoopGroupProvider: .singleton), acmeEndpoint: AcmeEndpoint = .letsEncrypt, logger: Logger = Logger.init(label: "AcmeSwift")) async throws {
         self.client = client
         self.server = acmeEndpoint.value
         self.logger = logger

--- a/Sources/AcmeSwift/APIs/AcmeSwift.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift.swift
@@ -24,7 +24,7 @@ public class AcmeSwift {
     private let logger: Logger
     private let decoder: JSONDecoder
     
-    public init(client: HTTPClient = .init(eventLoopGroupProvider: .singleton), acmeEndpoint: AcmeEndpoint = .letsEncrypt, logger: Logger = Logger.init(label: "AcmeSwift")) async throws {
+    public init(client: HTTPClient = .init(eventLoopGroupProvider: .shared(MultiThreadedEventLoopGroup.singleton)), acmeEndpoint: AcmeEndpoint = .letsEncrypt, logger: Logger = Logger.init(label: "AcmeSwift")) async throws {
         self.client = client
         self.server = acmeEndpoint.value
         self.logger = logger

--- a/Tests/AcmeSwiftTests/AccountTests.swift
+++ b/Tests/AcmeSwiftTests/AccountTests.swift
@@ -15,7 +15,7 @@ final class AccountTests: XCTestCase {
         
         var config = HTTPClient.Configuration(certificateVerification: .fullVerification, backgroundActivityLogger: self.logger)
         self.http = HTTPClient(
-            eventLoopGroupProvider: .createNew,
+            eventLoopGroupProvider: .singleton,
             configuration: config
         )
     }

--- a/Tests/AcmeSwiftTests/OrderTests.swift
+++ b/Tests/AcmeSwiftTests/OrderTests.swift
@@ -18,7 +18,7 @@ final class OrderTests: XCTestCase {
         
         let config = HTTPClient.Configuration(certificateVerification: .fullVerification, backgroundActivityLogger: self.logger)
         self.http = HTTPClient(
-            eventLoopGroupProvider: .createNew,
+            eventLoopGroupProvider: .singleton,
             configuration: config
         )
     }


### PR DESCRIPTION
Wanted to start by saying that this was a great package to use, and that I was able to get up and running integrating it into my setup in just a few hours (documented [here](https://youtube.com/live/j9bwupB1ox0))! Anyways, I have a few PRs to contribute back, based on my limited experience using it so far.

For this, I updated HTTPClient to default to using the singleton event loop group provider, which is now the recommendation in the ecosystem. Note that since this package is macOS/linux only, it may make more sense to use `.shared(MultiThreadedEventLoopGroup.singleton)` (which would match the group used in other packages like Vapor), but I'll leave the call to you.