### PR TITLE
Challenge Validation Documentation and Typos

### DIFF
--- a/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
@@ -17,7 +17,8 @@ extension AcmeSwift {
         
         
         /// List pending orders for the Account.
-        /// WARNING: no ACMEv2 provider seems to have this actually implemented. Doesn't work with Lets Encrypt.
+        ///
+        /// - Warning: No ACMEv2 provider seems to have this actually implemented. Doesn't work with Let's Encrypt.
         public func list() async throws -> [URL] {
             try await self.client.ensureLoggedIn()
             
@@ -32,7 +33,7 @@ extension AcmeSwift {
         }
         
         
-        /// Fetches the latest status of an existing Order
+        /// Fetches the latest status of an existing Order.
         /// - Parameters:
         ///   - url: The URL of the Order.
         public func get(url: URL) async throws -> AcmeOrderInfo {
@@ -44,7 +45,7 @@ extension AcmeSwift {
             return info
         }
         
-        /// Fetches the latest information about an existing Order
+        /// Fetches the latest information about an existing Order.
         /// - Parameters:
         ///   - order: an existing Order object to be updated.
         public func refresh(_ order: inout AcmeOrderInfo) async throws {
@@ -59,7 +60,7 @@ extension AcmeSwift {
         
         /// Creates an Order for obtaining a new certificate.
         /// - Parameters:
-        ///   - domains: The domains for which we want to create a certificate. Example: `["*.mydomain.com", "mydomain.com"]`
+        ///   - domains: The domains for which we want to create a certificate. Example: `["*.mydomain.com", "mydomain.com"]`.
         ///   - notBefore: Minimum Date when the future certificate will start being valid. **Note:** Let's Encrypt does not support setting this.
         ///   - notAfter: Desired expiration date of the future certificate. **Note:** Let's Encrypt does not support setting this.
         /// - Throws: Errors that can occur when executing the request.
@@ -87,7 +88,7 @@ extension AcmeSwift {
         
         /// Finalizes an Order and send the CSR.
         /// - Parameters:
-        ///   - order: The `AcmeOrderInfo` returned by the call to `.create()`
+        ///   - order: The `AcmeOrderInfo` returned by the call to `.create()`.
         ///   - withPemCsr: The CSR (Certificate Signing Request) **in PEM format**.
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  the `Account`.
@@ -104,9 +105,9 @@ extension AcmeSwift {
 
         /// Finalizes an Order and send the ECDSA CSR.
         /// - Parameters:
-        ///   - order: The `AcmeOrderInfo` returned by the call to `.create()`
-        ///   - subject: Subject of certificate
-        ///   - domains: Domains for certificate
+        ///   - order: The `AcmeOrderInfo` returned by the call to `.create()`.
+        ///   - subject: Subject of certificate.
+        ///   - domains: Domains for certificate.
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  `Certificate.PrivateKey`, `CertificateSigningRequest` and `Account`.
         public func finalizeWithEcdsa(order: AcmeOrderInfo, subject: String? = nil, domains: [String]) async throws -> (Certificate.PrivateKey, CertificateSigningRequest, AcmeOrderInfo) {
@@ -142,9 +143,9 @@ extension AcmeSwift {
 
         /// Finalizes an Order and send the RSA CSR.
         /// - Parameters:
-        ///   - order: The `AcmeOrderInfo` returned by the call to `.create()`
-        ///   - subject: Subject of certificate
-        ///   - domains: Domains for certificate
+        ///   - order: The `AcmeOrderInfo` returned by the call to `.create()`.
+        ///   - subject: Subject of certificate.
+        ///   - domains: Domains for certificate.
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  `Certificate.PrivateKey`, `CertificateSigningRequest` and `Account`.
         public func finalizeWithRsa(order: AcmeOrderInfo, subject: String? = nil, domains: [String]) async throws -> (Certificate.PrivateKey, CertificateSigningRequest, AcmeOrderInfo) {
@@ -180,7 +181,7 @@ extension AcmeSwift {
         
         /// Finalizes an Order and send the CSR.
         /// - Parameters:
-        ///   - order: The `AcmeOrderInfo` returned by the call to `.create()`
+        ///   - order: The `AcmeOrderInfo` returned by the call to `.create()`.
         ///   - withCsr: An instance of an `Certificate`.
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  the `Account`.
@@ -216,11 +217,13 @@ extension AcmeSwift {
         }
         
         /// Gets a user-friendly list of the Order challenges that need to be published.
+        ///
         /// These are the challenges that have a `pending` or `invalid` status.
-        /// NOTE: ALPN challenges are not returned.
+        ///
+        /// - Note: ALPN challenges are not returned.
         /// - Parameters:
         ///   - from: The `AcmeOrderInfo` representing the certificates Order.
-        ///   - preferring: Your preferred challenge validation method. Note: when requesting a wildcard certificate, a challenge will have to be published over DNS regardless of your preferred method..
+        ///   - preferring: Your preferred challenge validation method. Note: when requesting a wildcard certificate, a challenge will have to be published over DNS regardless of your preferred method.
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  a list of `ChallengeDescription` items that explain what information has to be published in order to validate the challenges.
         public func describePendingChallenges(from order: AcmeOrderInfo, preferring: AcmeAuthorization.Challenge.ChallengeType) async throws -> [ChallengeDescription] {
@@ -256,12 +259,19 @@ extension AcmeSwift {
             return descs
         }
         
-        /// Call this to get the ACMEv2 provider to verify the pending challenges once you have published them over HTTP or DNS
+        /// Call this to get the ACMEv2 provider to verify the pending challenges once you have published them over HTTP or DNS.
+        ///
+        /// Request challenges to be validated only after they have been published. 
+        /// - For DNS-based challenges, repeatedly wait and poll until the order expires or becomes invalid, or a timeout you define has been passed.
+        /// - For HTTP-based challenges, request verification once, then wait for the endpoints to have been called before requesting again. Similarly, repeat the process until the order expires or becomes invalid, or a timeout you define has been passed.
+        ///
+        /// - SeeAlso: [ACME Section 7.5.1 - Responding to Challenges](https://www.rfc-editor.org/rfc/rfc8555.html#section-7.5.1)
+        ///
         /// - Parameters:
         ///   - from: The `AcmeOrderInfo` representing the certificates Order.
         ///   - preferring: Your preferred challenge validation method. Note: when requesting a wildcard certificate, a challenge will have to be published over DNS regardless of your preferred method..
         /// - Throws: Errors that can occur when executing the request.
-        /// - Returns: Returns  a list of `AcmeAuthorization` containing the challenges that could **not** be validated.
+        /// - Returns: Returns  a list of `AcmeAuthorization` containing the challenges that were not validated yet and may be in the process of being validated, or have failed.
         @discardableResult
         public func validateChallenges(from order: AcmeOrderInfo, preferring: AcmeAuthorization.Challenge.ChallengeType) async throws -> [AcmeAuthorization.Challenge] {
             // get pending challenges
@@ -313,6 +323,7 @@ extension AcmeSwift {
         }
         
         /// Return the SHA256 digest of the ACMEv2 account public key's JWK JSON.
+        ///
         /// This value has to be present in an HTTP challenge value.
         private func getAccountThumbprint() throws -> Data {
             guard let login = self.client.login else {

--- a/Sources/AcmeSwift/Helpers/AcmeRequestBody.swift
+++ b/Sources/AcmeSwift/Helpers/AcmeRequestBody.swift
@@ -79,7 +79,7 @@ struct AcmeRequestBody<T: EndpointProtocol>: Encodable {
         self.payload = payload.body ?? (NoBody.init() as! T.Body)
     }
     
-    /// Encode as a JWT as described in ACMEv2 (RFC 8555)
+    /// Encode as a JWT as described in ACMEv2 (RFC 8555).
     func encode(to encoder: Encoder) throws {
         let jsonEncoder = JSONEncoder()
         jsonEncoder.dateEncodingStrategy = .iso8601
@@ -146,7 +146,7 @@ public struct JWK: Codable {
     }
 }
 
-// For requests that have an empty body
+/// For requests that have an empty body.
 struct NoBody: Codable {
     init(){}
 }

--- a/Sources/AcmeSwift/Helpers/String+base64Url.swift
+++ b/Sources/AcmeSwift/Helpers/String+base64Url.swift
@@ -2,6 +2,7 @@ import Foundation
 
 extension String {
     
+    /// Decodes a Base64 string into a decoded string.
     func fromBase64Url() -> String? {
         var base64 = self
         base64 = base64.replacingOccurrences(of: "-", with: "+")
@@ -15,6 +16,7 @@ extension String {
         return String(data: data, encoding: .utf8)
     }
     
+    /// Encodes the string as a Base64 string suitable for use as URL parameters.
     func toBase64Url() -> String {
         var result = Data(self.utf8).base64EncodedString()
         result = result.replacingOccurrences(of: "+", with: "-")
@@ -23,6 +25,7 @@ extension String {
         return result
     }
     
+    /// Converts a Base64 string to one suitable for use as URL parameters.
     func base64ToBase64Url() -> String {
         return self
             .replacingOccurrences(of: "+", with: "-")
@@ -30,6 +33,7 @@ extension String {
             .replacingOccurrences(of: "=", with: "")
     }
     
+    /// Converts a PEM certificate or key into a Base64 string suitable for use as URL parameters.
     func pemToBase64Url() -> String {
         return self.replacingOccurrences(of: "-----BEGIN CERTIFICATE REQUEST-----", with: "")
             .replacingOccurrences(of: "-----BEGIN CERTIFICATE-----", with: "")
@@ -40,7 +44,7 @@ extension String {
             .toBase64Url()
     }
     
-    /// This converts a PEM cert back to DER
+    /// Converts a PEM certificate or key back to DER.
     func pemToData() -> Data {
         let rawData = self.replacingOccurrences(of: "-----BEGIN CERTIFICATE REQUEST-----", with: "")
             .replacingOccurrences(of: "-----BEGIN CERTIFICATE-----", with: "")

--- a/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
+++ b/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
@@ -1,32 +1,33 @@
 import Foundation
 
-/// Account information returned when calling `get()` or `create()`
+/// Account information returned when calling `get()` or `create()`.
 public struct AcmeAccountInfo: Codable {
     
-    /// URL containing the ID of the Account
-    /// This URL is used to performa some account management operations.
+    /// URL containing the ID of the Account.
+    ///
+    /// - Note: This URL is used to perform some account management operations.
     internal(set) public var url: URL?
     
-    /// Information about the Account public key in JWK format
+    /// Information about the Account public key in JWK format.
     public let key: JWK
     
-    /// The PEM representation of the private key for this Account
+    /// The PEM representation of the private key for this Account.
     internal(set) public var privateKeyPem: String?
     
-    /// The contact entries
+    /// The contact entries.
     public let contact: [String]
     
-    /// Source IP (as seen by the ACME servers) from which the Account was created
+    /// Source IP (as seen by the ACME servers) from which the Account was created.
     public let initialIp: String
     
-    /// Date when the Account was created
+    /// Date when the Account was created.
     public let createdAt: String
     
-    /// Current status of the Account
+    /// Current status of the Account.
     public let status: Status
     
-    /// URL to the pending orders for this account
-    /// No provider seems to have this fully implemented
+    /// URL to the pending orders for this account.
+    /// - Note: No provider seems to have this fully implemented.
     public let orders: URL?
     
     public enum Status: String, Codable {

--- a/Sources/AcmeSwift/Models/AcmeError.swift
+++ b/Sources/AcmeSwift/Models/AcmeError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum AcmeError: Error {
-    // This Account information has no private key
+    /// This Account information has no private key
     case invalidAccountInfo
     
     /// You need to call `account.use()` before performing this operation

--- a/Sources/AcmeSwift/Models/Certificate/RevokeSpec.swift
+++ b/Sources/AcmeSwift/Models/Certificate/RevokeSpec.swift
@@ -2,10 +2,10 @@ import Foundation
 
 
 struct CertificateRevokeSpec: Codable {
-    /// PEM representation of the certificate
+    /// PEM representation of the certificate.
     public var certificate: String
     
-    /// Reason for the revocation
+    /// Reason for the revocation.
     public var reason: AcmeRevokeReason?
 }
 

--- a/Sources/AcmeSwift/Models/Order/AcmeAuthorization.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeAuthorization.swift
@@ -57,7 +57,7 @@ public struct AcmeAuthorization: Codable {
             /// A DNS challenge requiring the creation of TXT records to prove ownership of a domain or record.
             case dns = "dns-01"
 
-            /// A TLS-ALPN-01 challenge
+            /// A TLS-ALPN-01 challenge.
             case alpn = "tls-alpn-01"
         }
         

--- a/Sources/AcmeSwift/Models/Order/AcmeOrderInfo.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeOrderInfo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Information returned when creating a new Order
+/// Information returned when creating a new Order.
 public struct AcmeOrderInfo: Codable {
         
     /// The URL of this Order.
@@ -31,22 +31,26 @@ public struct AcmeOrderInfo: Codable {
     
     
     public enum OrderStatus: String, Codable {
-        /// The certificate will not be issued.  Consider thisorder process abandoned.
+        /// The certificate will not be issued. Consider this order process abandoned.
         case invalid
         
         /// The server does not believe that the client has fulfilled all the requirements.
-        ///  Check the "authorizations" array for entries that are still pending.
+        ///
+        /// Check the "authorizations" array for entries that are still pending.
         case pending
         
         /// The server agrees that the requirements have been fulfilled, and is awaiting finalization.
+        ///
         /// Submit a finalization request.
         case ready
         
         /// The certificate is being issued (`finalize()` has been called).
+        ///
         /// Send a POST-as-GET request after the time given in the Retry-After header field of the response, if any.
         case processing
         
         /// The server has issued the certificate and provisioned its URL to the "certificate" field of the order.
+        ///
         /// Download the certificate.
         case valid
     }

--- a/Sources/AcmeSwift/Models/Order/AcmeOrderSpec.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeOrderSpec.swift
@@ -10,10 +10,10 @@ public struct AcmeOrderSpec: Codable {
     
     public var identifiers: [Identifier]
     
-    /// The requested value of the notBefore field in the certificate
+    /// The requested value of the notBefore field in the certificate.
     public var notBefore: Date? = nil
     
-    /// The requested value of the notAfter field in the certificate
+    /// The requested value of the notAfter field in the certificate.
     public var notAfter: Date? = nil
     
     public struct Identifier: Codable {

--- a/Sources/AcmeSwift/Models/Order/ChallengeDescription.swift
+++ b/Sources/AcmeSwift/Models/Order/ChallengeDescription.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public struct ChallengeDescription: Codable {
-    /// The type of challgen.
-    /// For a wildcard certificate, there will **always** be a at least one DNS challenge, even if your proferred method is HTTP.
+    /// The type of challenge.
+    /// For a wildcard certificate, there will **always** be a at least one DNS challenge, even if your preferred method is HTTP.
     public let type: AcmeAuthorization.Challenge.ChallengeType
     
     /// For a DNS challenge, the full DNS record name.


### PR DESCRIPTION
Clarified documentation for validation and fixed some typos and inconsistencies I found along the way. Hopefully this makes it easier for others to figure out what's going wrong, as I had incorrectly assumed `validateChallenges` would await the challenges being successful rather than returning before the challenges were even queried (in the case of HTTP-01) 😅

I also added a blurb to the README to help folks validate their existing certs to determine if they should renew or not.