### PR TITLE
Added Sendable to public structs and enums

### DIFF
--- a/Sources/AcmeSwift/APIs/AcmeSwift.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift.swift
@@ -101,7 +101,7 @@ public class AcmeSwift {
     }
 }
 
-public enum AcmeEndpoint {
+public enum AcmeEndpoint: Sendable {
     /// The default, production Let's Encrypt endpoint
     case letsEncrypt
     /// The staging Let's Encrypt endpoint, for tests. Issues certificate not recognized by clients/browsers

--- a/Sources/AcmeSwift/Helpers/AcmeRequestBody.swift
+++ b/Sources/AcmeSwift/Helpers/AcmeRequestBody.swift
@@ -122,7 +122,7 @@ struct AcmeRequestBody<T: EndpointProtocol>: Encodable {
     }
 }
 
-public struct JWK: Codable {
+public struct JWK: Codable, Sendable {
     /// Key Type
     private(set) public var kty: KeyType = .ec
     
@@ -135,13 +135,13 @@ public struct JWK: Codable {
     /// The y coordinate for the Elliptic Curve point.
     private(set) public var y: String
     
-    public enum KeyType: String, Codable {
+    public enum KeyType: String, Codable, Sendable {
         case ec = "EC"
         case rsa = "RSA"
         case oct
     }
     
-    public enum CurveType: String, Codable {
+    public enum CurveType: String, Codable, Sendable {
         case p256 = "P-256"
     }
 }

--- a/Sources/AcmeSwift/Helpers/HttpClient+Decode.swift
+++ b/Sources/AcmeSwift/Helpers/HttpClient+Decode.swift
@@ -5,7 +5,7 @@ import Logging
 
 extension HTTPClientResponse {
     
-    public enum BodyError : Swift.Error {
+    public enum BodyError : Swift.Error, Sendable {
         case noBodyData
     }
     

--- a/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
+++ b/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Account information returned when calling `get()` or `create()`
-public struct AcmeAccountInfo: Codable {
-    
+public struct AcmeAccountInfo: Codable, Sendable {
+
     /// URL containing the ID of the Account
     /// This URL is used to performa some account management operations.
     internal(set) public var url: URL?
@@ -29,7 +29,7 @@ public struct AcmeAccountInfo: Codable {
     /// No provider seems to have this fully implemented
     public let orders: URL?
     
-    public enum Status: String, Codable {
+    public enum Status: String, Codable, Sendable {
         case valid, deactivated, revoked
     }
 }

--- a/Sources/AcmeSwift/Models/AcmeDirectory.swift
+++ b/Sources/AcmeSwift/Models/AcmeDirectory.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The Directory endpoint of the ACMEv2 service, providing discovery information about various endpoints
-public struct AcmeDirectory: Codable {
+public struct AcmeDirectory: Codable, Sendable {
     public let newAuthz: URL?
     public let newNonce: URL
     
@@ -12,7 +12,7 @@ public struct AcmeDirectory: Codable {
     public let keyChange: URL
     public let meta: Meta
     
-    public struct Meta: Codable {
+    public struct Meta: Codable, Sendable {
         public let termsOfService: URL?
         
         /// The web page of the ACME provider.

--- a/Sources/AcmeSwift/Models/AcmeError.swift
+++ b/Sources/AcmeSwift/Models/AcmeError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum AcmeError: Error {
+public enum AcmeError: Error, Sendable {
     // This Account information has no private key
     case invalidAccountInfo
     
@@ -30,7 +30,7 @@ public enum AcmeError: Error {
     case noDomains(String)
 }
 
-public struct AcmeResponseError: Codable, Error {
+public struct AcmeResponseError: Codable, Error, Sendable {
     public let type: AcmeErrorType
     
     public let title: String?
@@ -43,7 +43,7 @@ public struct AcmeResponseError: Codable, Error {
     
     public let subproblems: [AcmeResponseError]?
     
-    public enum AcmeErrorType: String, Codable, Error {
+    public enum AcmeErrorType: String, Codable, Error, Sendable {
         /// The request message was malformed
         case malformed = "urn:ietf:params:acme:error:malformed"
         
@@ -121,7 +121,7 @@ public struct AcmeResponseError: Codable, Error {
         case userActionRequired = "urn:ietf:params:acme:error:userActionRequired"
     }
     
-    public struct ErrorIdentifier: Codable {
+    public struct ErrorIdentifier: Codable, Sendable {
         public let type: String
         public let value: String
     }

--- a/Sources/AcmeSwift/Models/Certificate/RevokeSpec.swift
+++ b/Sources/AcmeSwift/Models/Certificate/RevokeSpec.swift
@@ -10,7 +10,7 @@ struct CertificateRevokeSpec: Codable {
 }
 
 /// Reason why we request for a certificate to be revoked.
-public enum AcmeRevokeReason: Int, Codable {
+public enum AcmeRevokeReason: Int, Codable, Sendable {
     case unspecified = 0
     case keyCompromise = 1
     case cACompromise = 2

--- a/Sources/AcmeSwift/Models/Order/AcmeAuthorization.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeAuthorization.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct AcmeAuthorization: Codable {
+public struct AcmeAuthorization: Codable, Sendable {
     public let status: AuthorizationStatus
     
     /// The timestamp after which the server will consider this authorization invalid
@@ -13,7 +13,7 @@ public struct AcmeAuthorization: Codable {
     /// Present and `true` if the current authorization is for a domain for which a wildcard certificate was requested.
     public let wildcard: Bool?
     
-    public enum AuthorizationStatus: String, Codable {
+    public enum AuthorizationStatus: String, Codable, Sendable {
         /// Initial status when the authorization is created.
         case pending
         
@@ -31,7 +31,7 @@ public struct AcmeAuthorization: Codable {
         case revoked
     }
     
-    public struct Challenge: Codable {
+    public struct Challenge: Codable, Sendable {
         /// The URL to which a response can be posted
         public let url: URL
         
@@ -50,7 +50,7 @@ public struct AcmeAuthorization: Codable {
         /// Error that occurred while the server was validating the challenge
         public let error: AcmeResponseError?
 
-        public enum ChallengeType: String, Codable {
+        public enum ChallengeType: String, Codable, Sendable {
             //// A HTTP challenge that requires publishing the contents of a challenge at a specific URL to prove ownership of the domain record.
             case http = "http-01"
 
@@ -61,7 +61,7 @@ public struct AcmeAuthorization: Codable {
             case alpn = "tls-alpn-01"
         }
         
-        public enum ChallengeStatus: String, Codable {
+        public enum ChallengeStatus: String, Codable, Sendable {
             case pending
             case processing
             case valid

--- a/Sources/AcmeSwift/Models/Order/AcmeOrderInfo.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeOrderInfo.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 /// Information returned when creating a new Order
-public struct AcmeOrderInfo: Codable {
-        
+public struct AcmeOrderInfo: Codable,Sendable {
+
     /// The URL of this Order.
     internal(set) public var url: URL?
     
@@ -30,7 +30,7 @@ public struct AcmeOrderInfo: Codable {
     public let certificate: URL?
     
     
-    public enum OrderStatus: String, Codable {
+    public enum OrderStatus: String, Codable, Sendable {
         /// The certificate will not be issued.  Consider thisorder process abandoned.
         case invalid
         

--- a/Sources/AcmeSwift/Models/Order/AcmeOrderSpec.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeOrderSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 
-public struct AcmeOrderSpec: Codable {
+public struct AcmeOrderSpec: Codable, Sendable {
     public init(identifiers: [AcmeOrderSpec.Identifier], notBefore: Date? = nil, notAfter: Date? = nil) {
         self.identifiers = identifiers
         self.notBefore = notBefore
@@ -16,13 +16,13 @@ public struct AcmeOrderSpec: Codable {
     /// The requested value of the notAfter field in the certificate
     public var notAfter: Date? = nil
     
-    public struct Identifier: Codable {
-        
+    public struct Identifier: Codable, Sendable {
+
         public var `type`: IdentifierType = .dns
         
         public var value: String
         
-        public enum IdentifierType: String, Codable {
+        public enum IdentifierType: String, Codable, Sendable {
             case dns
         }
     }

--- a/Sources/AcmeSwift/Models/Order/ChallengeDescription.swift
+++ b/Sources/AcmeSwift/Models/Order/ChallengeDescription.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ChallengeDescription: Codable {
+public struct ChallengeDescription: Codable, Sendable {
     /// The type of challgen.
     /// For a wildcard certificate, there will **always** be a at least one DNS challenge, even if your proferred method is HTTP.
     public let type: AcmeAuthorization.Challenge.ChallengeType


### PR DESCRIPTION
I was in the process of prepping my app for having 0 warnings from `SwiftSetting.enableExperimentalFeature("StrictConcurrency")`, and some Sendable issues surfaced from AcmeSwift.

Adding Sendable to most public enums and structs made the warnings go away, without introducing new ones.

I could not add Sendable to `AccountCredentials` because it references `Crypto.P256.Signing.PrivateKey` which is not Sendable yet.

I also tried bumping the swift-tools-version to 5.10 and applying StrictConcurrency to this project, and no warnings were raised. I did not add this to the PR, because I am not sure when you want to bump the required version of Swift.
