### PR TITLE
Update JWTKit Compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "2.1.0" ..< "4.0.0"),
-        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.13.1"),
+        .package(url: "https://github.com/vapor/jwt-kit.git", "4.13.1" ..< "6.0.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0")
     ],

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
@@ -327,14 +327,15 @@ extension AcmeSwift {
             guard let login = self.client.login else {
                 throw AcmeError.mustBeAuthenticated("\(AcmeSwift.self).init() must be called with an \(AccountCredentials.self)")
             }
-            let pubKey = try JWTKit.ECDSAKey.public(pem: login.key.publicKey.pemRepresentation)
-            guard let parameters = pubKey.parameters else {
-                throw AcmeError.invalidKeyError("Public key parameters are nil")
-            }
             
-            let jwk = JWK(
-                x: parameters.x,
-                y: parameters.y
+            let publicKey = login.key.publicKey.rawRepresentation
+            
+            let jwk = JWK.ecdsa(
+                nil,
+                identifier: nil,
+                x: publicKey.prefix(upTo: publicKey.count/2).base64EncodedString(),
+                y: publicKey.suffix(from: publicKey.count/2).base64EncodedString(),
+                curve: nil
             )
             let encoder = JSONEncoder()
             encoder.outputFormatting = .sortedKeys

--- a/Sources/AcmeSwift/Helpers/AcmeRequestBody.swift
+++ b/Sources/AcmeSwift/Helpers/AcmeRequestBody.swift
@@ -61,16 +61,16 @@ struct AcmeRequestBody<T: EndpointProtocol>: Encodable {
     
     init(accountURL: URL? = nil, privateKey: Crypto.P256.Signing.PrivateKey, nonce: String, payload: T) throws {
         self.privateKey = privateKey
-        let pubKey = try JWTKit.ECDSAKey.public(pem: privateKey.publicKey.pemRepresentation)
-        guard let parameters = pubKey.parameters else {
-            throw AcmeError.invalidKeyError("Public key parameters are nil")
-        }
+        let publicKey = privateKey.publicKey.rawRepresentation
         
         self.protected = .init(
             alg: .es256,
-            jwk: accountURL == nil ?  .init(
-                x: parameters.x,
-                y: parameters.y
+            jwk: accountURL == nil ? JWTKit.JWK.ecdsa(
+                nil,
+                identifier: nil,
+                x: publicKey.prefix(upTo: publicKey.count/2).base64EncodedString(),
+                y: publicKey.suffix(from: publicKey.count/2).base64EncodedString(),
+                curve: nil
             ) : nil,
             kid: accountURL,
             nonce: nonce,
@@ -119,30 +119,6 @@ struct AcmeRequestBody<T: EndpointProtocol>: Encodable {
         
         let signatureBase64 = signatureData.toBase64UrlString()
         try container.encode(signatureBase64, forKey: .signature)
-    }
-}
-
-public struct JWK: Codable, Sendable {
-    /// Key Type
-    private(set) public var kty: KeyType = .ec
-    
-    /// Curve
-    private(set) public var crv: CurveType = .p256
-    
-    /// The x coordinate for the Elliptic Curve point.
-    private(set) public var x: String
-    
-    /// The y coordinate for the Elliptic Curve point.
-    private(set) public var y: String
-    
-    public enum KeyType: String, Codable, Sendable {
-        case ec = "EC"
-        case rsa = "RSA"
-        case oct
-    }
-    
-    public enum CurveType: String, Codable, Sendable {
-        case p256 = "P-256"
     }
 }
 

--- a/Sources/AcmeSwift/Models/Account/AccountCredentials.swift
+++ b/Sources/AcmeSwift/Models/Account/AccountCredentials.swift
@@ -2,8 +2,8 @@ import Foundation
 import Crypto
 
 public struct AccountCredentials {
-    private (set) public var contacts: [String] = []
-    private (set) public var key: Crypto.P256.Signing.PrivateKey
+    private(set) public var contacts: [String] = []
+    private(set) public var key: Crypto.P256.Signing.PrivateKey
     
     public init(contacts: [String], pemKey: String) throws {
         let privateKey = try Crypto.P256.Signing.PrivateKey.init(pemRepresentation: pemKey)

--- a/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
+++ b/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JWTKit
 
 /// Account information returned when calling `get()` or `create()`.
 public struct AcmeAccountInfo: Codable, Sendable {

--- a/Sources/AcmeSwift/Models/AcmeError.swift
+++ b/Sources/AcmeSwift/Models/AcmeError.swift
@@ -19,8 +19,6 @@ public enum AcmeError: Error, Sendable {
     
     case jwsEncodeError(String)
     
-    case invalidKeyError(String)
-    
     case dataCorrupted(String)
     case errorCode(UInt, String?)
     


### PR DESCRIPTION
JWTKit is currently on a new major version, and depending on AcmeSwift prevents users from updating to that version. These changes add simultaneous compatibility for both versions 4 and 5 of JWTKit allowing folks to incrementally update as they need to.

This also fixes an issue with the Swift 6 language mode called out below.