### PR TITLE
Removed `initialIp` from AcmeAccountInfo

### DIFF
--- a/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
+++ b/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
@@ -18,9 +18,6 @@ public struct AcmeAccountInfo: Codable, Sendable {
     /// The contact entries.
     public let contact: [String]
     
-    /// Source IP (as seen by the ACME servers) from which the Account was created.
-    public let initialIp: String
-    
     /// Date when the Account was created.
     public let createdAt: String
     


### PR DESCRIPTION
Removed `initialIp` as it has been fully deprecated, and causes renewal failures: https://community.letsencrypt.org/t/has-the-output-of-initialip-changed-in-the-account-directory/229823