### PR TITLE
Missing Contact

### DIFF
--- a/Sources/AcmeSwift/APIs/AcmeSwift+Account.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Account.swift
@@ -76,7 +76,7 @@ extension AcmeSwift {
                 throw AcmeError.invalidAccountInfo
             }
             self.client.login = try .init(
-                contacts: account.contact,
+                contacts: account.contact ?? [],
                 pemKey: privateKey
             )
         }

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Account.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Account.swift
@@ -43,13 +43,7 @@ extension AcmeSwift {
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  an `Account` that can be saves for future connections.
         public func create(contacts: [String], acceptTOS: Bool) async throws -> AcmeAccountInfo {
-            var contactsWithURL: [String] = []
-            for var contact in contacts {
-              if contact.firstIndex(of: ":") == nil {
-                contact = "mailto:" + contact
-              }
-              contactsWithURL.append(contact)
-            }
+            let contactsWithSchema = contacts.map { $0.contains(":") ? $0 : "mailto:\($0)" }
             
             // Create private key
             let privateKey = Crypto.P256.Signing.PrivateKey.init(compactRepresentable: true)
@@ -57,7 +51,7 @@ extension AcmeSwift {
             let ep = CreateAccountEndpoint(
                 directory: self.client.directory,
                 spec: .init(
-                    contact: contactsWithURL,
+                    contact: contactsWithSchema,
                     termsOfServiceAgreed: acceptTOS,
                     onlyReturnExisting: false,
                     externalAccountBinding: nil

--- a/Sources/AcmeSwift/Models/Account/AccountCredentials.swift
+++ b/Sources/AcmeSwift/Models/Account/AccountCredentials.swift
@@ -12,11 +12,6 @@ public struct AccountCredentials {
     
     public init(contacts: [String], key: Crypto.P256.Signing.PrivateKey) {
         self.key = key
-        for var contact in contacts {
-            if contact.firstIndex(of: ":") == nil {
-                contact = "mailto:" + contact
-            }
-            self.contacts.append(contact)
-        }
+        self.contacts = contacts.map { $0.contains(":") ? $0 : "mailto:\($0)" }
     }
 }

--- a/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
+++ b/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
@@ -16,7 +16,11 @@ public struct AcmeAccountInfo: Codable, Sendable {
     internal(set) public var privateKeyPem: String?
     
     /// The contact entries.
-    public let contact: [String]
+    ///
+    /// An array of URLs that the server can use to contact the client for issues related to this account. For example, the server may wish to notify the client about server-initiated revocation or certificate expiration. For information on supported URL schemes, see [Section 7.3](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3).
+    ///
+    /// - SeeAlso: [RFC 8555 Automatic Certificate Management Environment (ACME) §7.1.2. Acount Objects](https://datatracker.ietf.org/doc/html/rfc8555#section-7.1.2)
+    public let contact: [String]?
     
     /// Date when the Account was created.
     public let createdAt: String


### PR DESCRIPTION
The account object now seems to look like this as of ~June 10th, preventing renewals from being proceeding, so I've made the `contact` field optional as the spec suggests it should be. I haven't however found a spec that specifies the `key` and `createdAt` keys, so it's perfectly likely this changes again in the future 😅
```
{
   "key": {
     "kty": "EC",
     "crv": "P-256",
     "x": "...",
     "y": "..."
   },
   "createdAt": "2024-01-10T14:55:46Z",
   "status": "valid"
}
```

Also spotted some opportunities for other minor improvements, but I can pull those out into separate PRs if you prefer.

Fixes #17 