### PR TITLE
Acme DA support

### DIFF
--- a/Examples/acme-da/AcmeDA.swift
+++ b/Examples/acme-da/AcmeDA.swift
@@ -33,7 +33,7 @@ struct AcmeDA: AsyncParsableCommand {
 
             After configuring "step-ca" the first thing that we need is to create a key in
             one of the YubiKey slots. We're picking 82 in this example. To do this, we will
-            use "step" [2] with the "step-kms-plugin" [2], and we will run the following:
+            use "step" [2] with the "step-kms-plugin" [3], and we will run the following:
 
             step kms create "yubikey:slot-id=82?pin-value=123456"
 

--- a/Examples/acme-da/AcmeDA.swift
+++ b/Examples/acme-da/AcmeDA.swift
@@ -1,0 +1,180 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+import AcmeSwift
+import ArgumentParser
+import AsyncHTTPClient
+import Foundation
+import Logging
+import NIOSSL
+import X509
+
+let processName = ProcessInfo.processInfo.processName
+
+@main
+struct AcmeDA: AsyncParsableCommand {  
+    static var configuration: CommandConfiguration {
+        CommandConfiguration(
+            abstract: "An example of usage of ACME-DA with step-ca.",
+            usage: "STTY=-icanon \(processName) <permanent-identifier> <csr-file> <directory> --cacert <cacert>",
+            discussion: """
+            To be able to run this example, we need to use a key that can be attested,
+            "step-ca" [1], for example, supports attestation using YubiKey 5 Series.
+
+            To configure "step-ca" with device-attest-01 support, you need to create an ACME
+            provisioner with the device-attest-01 challenge enabled. In the ca.json the
+            provisioner looks like this:
+
+            {
+                "type": "ACME",
+                "name": "attestation",
+                "challenges": [ "device-attest-01" ]
+            }
+
+            After configuring "step-ca" the first thing that we need is to create a key in
+            one of the YubiKey slots. We're picking 82 in this example. To do this, we will
+            use "step" [2] with the "step-kms-plugin" [2], and we will run the following:
+
+            step kms create "yubikey:slot-id=82?pin-value=123456"
+
+            Then we need to create a CSR signed by this new key. This CSR must include the
+            serial number in the Permanent Identifier Subject Alternative Name extension.
+            The serial number of a YubiKey is printed on the key, but it is also available
+            in an attestation certificate. You can see it running:
+
+            step kms attest "yubikey:slot-id=82?pin-value=123456" | \
+            step certificate inspect
+
+            To add the permanent identifier, we will need to use the following template:
+
+            {
+                "subject": {{ toJson .Subject }},
+                "sans": [{
+                    "type": "permanentIdentifier",
+                    "value": {{ toJson .Subject}}
+                }]
+            }
+
+            Having the template in "attestation.tpl", and assuming the serial number is
+            123456789, we can get the proper CSR running:
+
+            step certificate create --csr --template attestation.tpl \
+            --kms "yubikey:?pin-value=123456" --key "yubikey:slot-id=82" \
+            123456789 att.csr
+
+            With this we can run this program with the new CSR:
+
+            STTY=-icanon \(processName) 123456789 att.csr https://localhost:9000/acme/attestation/directory
+
+            The program will ask you to create an attestation of the ACME Key Authorization,
+            running:
+
+            echo -n <key-authorization> | \
+            step kms attest --format step "yubikey:slot-id=82?pin-value=123456"
+
+            Note that because the input that we need to paste is usually more than 1024
+            characters, the "STTY=-icanon" environment variable is required.
+
+            [1] step-ca         - https://github.com/smallstep/certificates
+            [2] step            - https://github.com/smallstep/cli
+            [3] step-kms-plugin - https://github.com/smallstep/step-kms-plugin
+            """)
+    }
+
+    @Argument(help: "The permanent identifier to use.")
+    public var permanentIdentifier: String
+
+    @Argument(help: "The path of the CSR file to use.")
+    public var csrFile: String
+
+    @Argument(help: "The URL of the ACME directory to use.")
+    public var directory: String
+
+    @Option(help: "The path to the CA certificate to verify peer against.")
+    public var cacert: String
+
+    
+    public func run() async throws {
+        if ProcessInfo.processInfo.environment["STTY"] != "-icanon" {
+            print("Please run this program with the environment variable STTY=-icanon")
+            return
+        }
+
+        let logger = Logger.init(label: "acme-da")
+
+        let directoryURL = URL(string: directory)!
+        let csrFileURL = URL(fileURLWithPath: csrFile)
+
+        // Parse CSR
+        let csrPem = try String(contentsOf: csrFileURL, encoding: .utf8)
+        let csr = try CertificateSigningRequest(pemEncoded: csrPem)
+
+        // Initialize HTTP client with optional root
+        var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
+        if cacert != "" {
+            tlsConfiguration.trustRoots = .file(cacert)
+        }
+        var config = HTTPClient.Configuration(
+            certificateVerification: .fullVerification, backgroundActivityLogger: logger)
+        config.tlsConfiguration = tlsConfiguration
+        let client = HTTPClient(
+            eventLoopGroupProvider: .singleton,
+            configuration: config,
+        )
+
+        // Initialize ACME client
+        let acme = try await AcmeSwift(
+            client: client, acmeEndpoint: .custom(directoryURL), logger: logger)
+        defer { try? acme.syncShutdown() }
+
+        // Initialize ACME account
+        let contacts: [String] = ["mailto:you@example.com"]
+        let account = try await acme.account.create(contacts: contacts, acceptTOS: true)
+        try acme.account.use(account)
+
+        var attObj: String = ""
+        var order = try await acme.orders.create(permanentIdentifier: permanentIdentifier)
+        for desc in try await acme.orders.describePendingChallenges(
+            from: order, preferring: .deviceAttest)
+        {
+            print("Now you need to sign following keyAuthorization:")
+            print(desc.value)
+            print()
+            print("To do this you can use step-kms-plugin running:")
+            print(
+                "echo -n \(desc.value) | step kms attest --format step \"yubikey:slot-id=82?pin-value=123456\""
+            )
+            print()
+            print("Please enter the base64 output and press Enter:")
+            if let str = readLine() {
+                attObj = str
+            } else {
+                print("No input was provided.")
+                return
+            }
+        }
+
+        let payload = acme.orders.createAttestationPayload(attObj: attObj)
+        let updatedChallenges = try await acme.orders.validateChallenges(
+            from: order, preferring: .deviceAttest, payload: payload)
+        if updatedChallenges.count == 0 {
+            fatalError("Challenged failed")
+        }
+        try await acme.orders.refresh(&order)
+
+        let info = try await acme.orders.finalize(order: order, withCsr: csr)
+        let certs = try await acme.certificates.download(for: info)
+        print()
+        for crt in certs {
+            print(crt)
+        }
+    }
+}
+
+struct AcmeAttestationSpec: Codable {
+    init(attObj: String) {
+        self.attObj = attObj
+    }
+    
+    var attObj: String
+}

--- a/Examples/acme-da/attestation.tpl
+++ b/Examples/acme-da/attestation.tpl
@@ -1,0 +1,7 @@
+{ 
+    "subject": {{ toJson .Subject }},
+    "sans": [{
+        "type": "permanentIdentifier", 
+        "value": {{ toJson .Subject.CommonName }}
+    }]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "2.1.0" ..< "4.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", "4.13.1" ..< "6.0.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.2.0"),
-        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0")
+        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -36,7 +37,14 @@ let package = Package(
             name: "AcmeSwiftTests",
             dependencies: [
                 "AcmeSwift"
-            ]
+            ]),
+         .executableTarget(
+            name: "acme-da",
+            dependencies: [
+                "AcmeSwift",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Examples/acme-da",
         ),
     ]
 )

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Account.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Account.swift
@@ -73,6 +73,7 @@ extension AcmeSwift {
                 contacts: account.contact ?? [],
                 pemKey: privateKey
             )
+            self.client.accountURL = account.url
         }
         
         /// Use an existing Account for the ACMEv2 provider

--- a/Sources/AcmeSwift/APIs/AcmeSwift.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift.swift
@@ -66,6 +66,16 @@ public class AcmeSwift {
             self.accountURL = info.url
         }
     }
+
+    /// Returns the host header for the given URL, including port if not default.
+    internal func getHostHeader(url: URL) -> String {
+        var host = url.host ?? "localhost"
+        if let port = url.port, port != 443 {
+            host += ":\(port)"
+        }
+        return host
+    }
+
     /// Executes a request to a specific endpoint. The `Endpoint` struct provides all necessary data and parameters for the request.
     /// - Parameter endpoint: `Endpoint` instance with all necessary data and parameters.
     /// - Throws: It can throw an error when encoding the body of the `Endpoint` request to JSON.
@@ -75,7 +85,7 @@ public class AcmeSwift {
         logger.debug("\(Self.self) execute Endpoint \(T.self): \(endpoint.method) \(endpoint.url)")
         
         var finalHeaders: HTTPHeaders = .init()
-        finalHeaders.add(name: "Host", value: endpoint.url.host ?? "localhost")
+        finalHeaders.add(name: "Host", value: getHostHeader(url: endpoint.url))
         finalHeaders.add(contentsOf: self.headers)
         if let additionalHeaders = endpoint.headers {
             finalHeaders.add(contentsOf: additionalHeaders)

--- a/Sources/AcmeSwift/Endpoints/Order/ValidateAttestationChallangeEndpoint.swift
+++ b/Sources/AcmeSwift/Endpoints/Order/ValidateAttestationChallangeEndpoint.swift
@@ -1,0 +1,15 @@
+import Foundation
+import NIOHTTP1
+
+struct ValidateAttestationChallengeEndpoint: EndpointProtocol {
+    var body: Body?
+    
+    typealias Response = AcmeAuthorization.Challenge
+    typealias Body = AcmeAttestationSpec
+    let url: URL
+    
+    init(challengeURL: URL, spec: AcmeAttestationSpec) {
+        self.body = spec
+        self.url = challengeURL
+    }
+}

--- a/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
+++ b/Sources/AcmeSwift/Models/Account/AcmeAccountInfo.swift
@@ -10,7 +10,7 @@ public struct AcmeAccountInfo: Codable, Sendable {
     internal(set) public var url: URL?
     
     /// Information about the Account public key in JWK format.
-    public let key: JWK
+    public let key: JWK?
     
     /// The PEM representation of the private key for this Account.
     internal(set) public var privateKeyPem: String?
@@ -23,7 +23,7 @@ public struct AcmeAccountInfo: Codable, Sendable {
     public let contact: [String]?
     
     /// Date when the Account was created.
-    public let createdAt: String
+    public let createdAt: String?
     
     /// Current status of the Account.
     public let status: Status

--- a/Sources/AcmeSwift/Models/AcmeDirectory.swift
+++ b/Sources/AcmeSwift/Models/AcmeDirectory.swift
@@ -10,7 +10,7 @@ public struct AcmeDirectory: Codable, Sendable {
     public let newOrder: URL
     public let revokeCert: URL
     public let keyChange: URL
-    public let meta: Meta
+    public let meta: Meta?
     
     public struct Meta: Codable, Sendable {
         public let termsOfService: URL?

--- a/Sources/AcmeSwift/Models/Order/AcmeAttestationSpec.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeAttestationSpec.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct AcmeAttestationSpec: Codable {
+    init(attObj: String) {
+        self.attObj = attObj
+    }
+    
+    var attObj: String
+}

--- a/Sources/AcmeSwift/Models/Order/AcmeAuthorization.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeAuthorization.swift
@@ -59,6 +59,9 @@ public struct AcmeAuthorization: Codable, Sendable {
 
             /// A TLS-ALPN-01 challenge.
             case alpn = "tls-alpn-01"
+
+            /// A device attestation challenge, see  https://datatracker.ietf.org/doc/draft-acme-device-attest/
+            case deviceAttest = "device-attest-01"
         }
         
         public enum ChallengeStatus: String, Codable, Sendable {

--- a/Sources/AcmeSwift/Models/Order/AcmeOrderSpec.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeOrderSpec.swift
@@ -24,6 +24,7 @@ public struct AcmeOrderSpec: Codable, Sendable {
         
         public enum IdentifierType: String, Codable, Sendable {
             case dns
+            case permanentIdentifier = "permanent-identifier"
         }
     }
 }

--- a/Sources/AcmeSwift/Models/Order/ChallengeDescription.swift
+++ b/Sources/AcmeSwift/Models/Order/ChallengeDescription.swift
@@ -11,6 +11,7 @@ public struct ChallengeDescription: Codable, Sendable {
     
     /// For a DNS challenge, the **TXT** record value.
     /// For an HTTP challenge, the exact value that the `endpoint` must return over HTTP on port 80.
+    /// For a device-attest-01 challenge, the data to be signed.
     public let value: String
     
     /// The ACMEv2 server URL for validating this challenge.


### PR DESCRIPTION
### Description

This PR is written on top of https://github.com/m-barthelemy/AcmeSwift/pull/19 and adds support for the device-attest-01 challenge. This challenge allows device attestation using YubiKeys, TPMs, and in theory keys in the Secure Enclave.

Apple's [ACMECertificate](https://developer.apple.com/documentation/devicemanagement/acmecertificate) uses this challenge to get certificates from an MDM.

This PR also includes an example for using the device-attest-01 challenge with [step-ca](http://github.com/smallstep/certificates), an open-source certificate authority with ACME-DA support. The example shows the use with a YubiKey, although with the right tooling other devices can also be supported.