### PR TITLE
Basic support for ARI (ACME Renewal Information)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ var renewOrder = try await acme.orders.replace(certificate: x509)
 
 ```
 
-Then treat `renewOrder` as a regular order: grab the challenges, publish them, request their validation, and finalize the order.
+Then treat `renewOrder` like a regular order: grab the challenges, publish them, request their validation, and finalize the order.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This is an ACME v2 client written in Swift.
 
-It fully uses the Swift concurrency features introduced with Swift 5.5 (`async`/`await`).
-
 
 ## Note
 - This library doesn't handle any ACME challenge at all by itself. Publishing the challenge, either by creating DNS record or exposing the value over HTTP, is out of scope. 
@@ -54,7 +52,7 @@ let acme = try await AcmeSwift(acmeEndpoint: .letsEncryptStaging)
 
 ### Account
 
-- Create a new Let's Encrypt account:
+#### Create a new Let's Encrypt account:
 
 ```swift
 let account = acme.account.create(contacts: ["my.email@domain.com"], validateTOS: true)
@@ -69,7 +67,7 @@ For example, you can encode it to JSON, save it somewhere and then decode it in 
 
 <br/>
 
-- Reuse a previously created account:
+#### Reuse a previously created account:
 
 Option 1: Directly use the object returned by `account.create(...)`
 ```swift
@@ -86,7 +84,7 @@ If you created your account using AcmeSwift, the private key in PEM format is st
 
 <br/>
 
-- Deactivate an existing account:
+#### Deactivate an existing account:
 
 > [!CAUTION]
 > Only use this if you are absolutely certain that the account needs to be permanently deactivated. There is no going back!
@@ -101,7 +99,7 @@ try await acme.account.deactivate()
 
 ### Orders (certificate requests)
 
-Fetch an Order by its URL:
+#### Fetch an Order by its URL:
 ```swift
 let latest = try await acme.orders.get(url: order.url!)
 ```
@@ -109,7 +107,7 @@ let latest = try await acme.orders.get(url: order.url!)
 <br/>
 
 
-Refresh an Order instance with latest information from the server:
+#### Refresh an Order instance with latest information from the server:
 ```swift
 try await acme.orders.refresh(&order)
 ```
@@ -117,7 +115,7 @@ try await acme.orders.refresh(&order)
 <br/>
 
 
-Create an Order for a new certificate:
+#### Create an Order for a new certificate:
 ```swift
  
 var order = try await acme.orders.create(domains: ["mydomain.com", "www.mydomain.com"])
@@ -125,7 +123,7 @@ var order = try await acme.orders.create(domains: ["mydomain.com", "www.mydomain
 
 <br/>
 
-Get the Order authorizations and challenges: 
+#### Get the Order authorizations and challenges: 
 ```swift
 let authorizations = try await acme.orders.getAuthorizations(from: order)
 ```
@@ -150,13 +148,14 @@ Let's Encrypt only allows DNS validation for wildcard certificates.
 
 <br/>
 
-Once the challenges are published, we can ask Let's Encrypt to validate them:
+#### Ask Let's Encrypt to validate the challenges:
 ```swift
 let updatedChallenges = try await acme.orders.validateChallenges(from: order, preferring: .http)
 ```
 
 <br/>
 
+#### Finalize the order
 Once all the authorizations/challenges are valid, we can finalize the Order by sending the CSR in PEM format.
 
 If you already have a CSR:
@@ -185,9 +184,28 @@ print("\n• Private key: \(try privateKey.serializeAsPEM().pemString)")
 
 <br/>
 
+After that you can [download your certificate](#download-a-certificate)
+
+### Renewals (ARI)
+Historically, the ACMEv2 protocol had no such concept, and renewing a certificate was just a matter of creating a new order. 
+While this is still a valid option, a new order counts against Let's Encrypt rate limits, and does not allow to know if certificate should be renewed earlier than anticipated due to an issue on the CA side. 
+[RFC9773](https://www.rfc-editor.org/rfc/rfc9773.html) adds support for certificates renewals, and for obtaining information about the suggested renewal window.
+
+To renew a certificate:
+
+```swift
+var renewOrder = try await acme.orders.replace(certificate: x509)
+
+```
+
+Then treat `renewOrder` as a regular order: grab the challenges, publish them, request their validation, and finalize the order.
+
+<br/>
+
+
 ### Certificates
 
-- Download a certificate:
+#### Download a certificate:
 
 > This assumes that the corresponding Order has been finalized successfully, meaning that the Order `status` field is `valid`.
 
@@ -209,48 +227,31 @@ try certs.joined(separator: "\n")
 
 <br/>
 
-- Revoke a certificate:
+#### Revoke a certificate:
 ```swift
 try await acme.certificates.revoke(certificatePem: "....")
 ```
 
-#### Validating Existing Certificates
+<br/>
 
-Since Let's Encrypt recommends only renewing certificates after 60 days, it's often useful to check existing certificates for validity before requesting a new one:
+#### Check if/when a certificate should be renewed
 
 ```swift
-import NIOSSL
-
-let certURL = URL(fileURLWithPath: "cert.pem").absoluteURL
-let domains = ["*.ponies.com", "ponies.com"]
-logger.notice("Refreshing certificate for \(domains.joined(separator: ", "))")
-
-do {
-    let existingCerts = try NIOSSLCertificate.fromPEMFile(certURL.path(percentEncoded: false))
-    
-    logger.notice("Found existing certificates: \(existingCerts)")
-    if let certificate = existingCerts.first {
-        let expirationDate = Date(timeIntervalSince1970: TimeInterval(certificate.notValidAfter))
-        
-        /// Get the names gregistered in the current certificate to see if they changed
-        let allNames = Set(certificate._subjectAlternativeNames().map { name -> String? in
-            guard case .dnsName = name.nameType else { return nil }
-            return String(decoding: name.contents, as: UTF8.self)
-        }.compactMap { $0 })
-        
-        /// If the expiration date is more than 2 months away and contains all the domains we are interested in, stop renewing.
-        if expirationDate.timeIntervalSinceNow > 60*24*60*60 && allNames.isSuperset(of: domains) {
-            logger.notice("Certificate for \(domains.joined(separator: ", ")) still valid. Expires on \(expirationDate). Renewing on \(expirationDate.advanced(by: -30*24*60*60))")
-            return
-        }
-    }
-} catch {
-    // Catch any errors here to log them, but otherwise continue
-    logger.notice("An issue occured loading existing certificates: \(error)")
+let renewalInfo = try await acme.certificates.getRenewalInfo(certificatePem: ...)
+if renewalInfo.suggestedWindow.start < Date() {
+    print("It's time to renew!")
 }
-
-// ... Continue renewing certificate
+else if let nextCheck = renewalInfo.nextCheck {
+    print("We should be checking again at \(Date().addingTimeInterval(nextCheck))")
+}
 ```
+
+See how to [make a renewal order](#renewals-ari).
+
+> [!NOTE]  
+> If you trigger the renewal within the renewal window, Let's Encrypt rate limits do not apply.
+
+<br/>
 
 ## Example
 

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Certificates.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Certificates.swift
@@ -1,4 +1,5 @@
 import Foundation
+import X509
 
 extension AcmeSwift {
     /// APIs related to ACMEv2 certificates management.
@@ -35,6 +36,7 @@ extension AcmeSwift {
         /// Revokes a previously issued certificate.
         /// - Parameters:
         ///   - certificatePem: The Certificate **in PEM format**.
+        ///   - reason: An optional justification for the revocation.
         public func revoke(certificatePem: String, reason: AcmeRevokeReason? = nil) async throws {
             try await self.client.ensureLoggedIn()
             
@@ -46,6 +48,42 @@ extension AcmeSwift {
                 spec: .init(certificate: pemStr, reason: reason)
             )
             let (_, _) = try await self.client.run(ep, privateKey: self.client.login!.key, accountURL: client.accountURL!)
+        }
+
+        /// Gets the Automated Renewal Information for a certificate.
+        /// - Parameters:
+        ///   - certificate: The X509.Certificate.
+        /// - Returns: Returns an `AcmeCertificateRenewalInfo` object with the currently recommended time window to renew the certificate (`suggestedWindow` property).
+        ///
+        ///   If a certificate issued by Let'sEncrypt is renewed during this interval, the renewal is exempted from rate limits.
+        public func getRenewalInfo(for certificate: X509.Certificate) async throws -> AcmeCertificateRenewalInfo {
+            try await self.client.ensureLoggedIn()
+
+            guard var ariURL = self.client.directory.renewalInfo else {
+                throw AcmeError.unsupportedFeature(\.renewalInfo)
+            }
+
+            let ariCertId = try certificate.getARICertId()
+            ariURL.append(path: ariCertId)
+
+            let ep = GetCertificateARIEndpoint(url: ariURL)
+            var (ariInfo, headers) = try await self.client.run(ep, privateKey: self.client.login!.key, accountURL: client.accountURL!)
+            if let retryAfterRaw = headers["Retry-After"].first, let retryAfterSec = Int(retryAfterRaw) {
+                ariInfo.nextCheck = TimeInterval(retryAfterSec)
+            }
+            
+            return ariInfo
+        }
+
+        /// Gets the Automated Renewal Information for a certificate.
+        /// - Parameters:
+        ///   - certificatePem: The Certificate **in PEM format**.
+        /// - Returns: Returns an `AcmeCertificateRenewalInfo` object with the currently recommended time window to renew the certificate (`suggestedWindow` property).
+        ///
+        ///   If a certificate issued by Let'sEncrypt is renewed during this interval, the renewal is exempted from rate limits.
+        public func getRenewalInfo(certificatePem: String) async throws -> AcmeCertificateRenewalInfo {
+            let x509 = try Certificate(pemEncoded: certificatePem)
+            return try await getRenewalInfo(for: x509)
         }
     }
 }

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Certificates.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Certificates.swift
@@ -35,12 +35,12 @@ extension AcmeSwift {
         
         /// Revokes a previously issued certificate.
         /// - Parameters:
-        ///   - certificatePem: The Certificate **in PEM format**.
+        ///   - pemEncoded: The Certificate **in PEM format**.
         ///   - reason: An optional justification for the revocation.
-        public func revoke(certificatePem: String, reason: AcmeRevokeReason? = nil) async throws {
+        public func revoke(pemEncoded: String, reason: AcmeRevokeReason? = nil) async throws {
             try await self.client.ensureLoggedIn()
             
-            let csrBytes = certificatePem.pemToData()
+            let csrBytes = pemEncoded.pemToData()
             let pemStr = csrBytes.toBase64UrlString()
             
             let ep = RevokeCertificateEndpoint(
@@ -77,12 +77,12 @@ extension AcmeSwift {
 
         /// Gets the Automated Renewal Information for a certificate.
         /// - Parameters:
-        ///   - certificatePem: The Certificate **in PEM format**.
+        ///   - pemEncoded: The Certificate **in PEM format**.
         /// - Returns: Returns an `AcmeCertificateRenewalInfo` object with the currently recommended time window to renew the certificate (`suggestedWindow` property).
         ///
         ///   If a certificate issued by Let'sEncrypt is renewed during this interval, the renewal is exempted from rate limits.
-        public func getRenewalInfo(certificatePem: String) async throws -> AcmeCertificateRenewalInfo {
-            let x509 = try Certificate(pemEncoded: certificatePem)
+        public func getRenewalInfo(pemEncoded: String) async throws -> AcmeCertificateRenewalInfo {
+            let x509 = try Certificate(pemEncoded: pemEncoded)
             return try await getRenewalInfo(for: x509)
         }
     }

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
@@ -276,16 +276,17 @@ extension AcmeSwift {
         /// - Note: ALPN challenges are not returned.
         /// - Parameters:
         ///   - from: The `AcmeOrderInfo` representing the certificates Order.
-        ///   - preferring: Your preferred challenge validation method. Note: when requesting a wildcard certificate, a challenge will have to be published over DNS regardless of your preferred method.
+        ///   - preferring: Your preferred challenge validation method. If not set, all the possible challenges for all records will be returned.
+        ///     Note: when requesting a wildcard certificate, a challenge will have to be published over DNS regardless of your preferred method.
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  a list of `ChallengeDescription` items that explain what information has to be published in order to validate the challenges.
-        public func describePendingChallenges(from order: AcmeOrderInfo, preferring: AcmeAuthorization.Challenge.ChallengeType) async throws -> [ChallengeDescription] {
-            
+        public func describePendingChallenges(from order: AcmeOrderInfo, preferring: AcmeAuthorization.Challenge.ChallengeType? = nil) async throws -> [ChallengeDescription] {
+
             let accountThumbprint = try getAccountThumbprint()
             let authorizations = try await getAuthorizations(from: order)
             var descs: [ChallengeDescription] = []
             for auth in authorizations where auth.status == .pending {
-                for challenge in auth.challenges where (challenge.type == preferring || auth.wildcard == true) && (challenge.status == .pending || challenge.status == .invalid) {
+                for challenge in auth.challenges where (preferring == nil || challenge.type == preferring || auth.wildcard == true) && (challenge.status == .pending || challenge.status == .invalid) {
 
                     switch challenge.type {
                     case .dns:
@@ -341,7 +342,7 @@ extension AcmeSwift {
                             digest += "; policy=wildcard"
                         }
                         let challengeDesc = ChallengeDescription(
-                            type: preferring,
+                            type: .dnsPersist,
                             endpoint: "_validation-persist.\(auth.identifier.value)",
                             value: digest,
                             token: nil,
@@ -363,6 +364,9 @@ extension AcmeSwift {
                             url: challenge.url
                         )
                         descs.append(challengeDesc)
+
+                    case .alpn:
+                        continue
 
                     default:
                         throw AcmeError.unsupportedChallenge(type: challenge.type)
@@ -386,7 +390,7 @@ extension AcmeSwift {
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  a list of `AcmeAuthorization` containing the challenges that were not validated yet and may be in the process of being validated, or have failed.
         @discardableResult
-        public func validateChallenges(from order: AcmeOrderInfo, preferring: AcmeAuthorization.Challenge.ChallengeType, payload: Codable? = nil) async throws -> [AcmeAuthorization.Challenge] {
+        public func validateChallenges(from order: AcmeOrderInfo, preferring: AcmeAuthorization.Challenge.ChallengeType? = nil, payload: Codable? = nil) async throws -> [AcmeAuthorization.Challenge] {
             // get pending challenges
             let pendingChallenges = try await describePendingChallenges(from: order, preferring: preferring)
             var updatedChallenges: [AcmeAuthorization.Challenge] = []

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
@@ -35,6 +35,7 @@ extension AcmeSwift {
         /// Fetches the latest status of an existing Order.
         /// - Parameters:
         ///   - url: The URL of the Order.
+        /// - Returns: Returns  an `AcmeOrderInfo` for the specified order URL
         public func get(url: URL) async throws -> AcmeOrderInfo {
             try await self.client.ensureLoggedIn()
 
@@ -46,7 +47,7 @@ extension AcmeSwift {
         
         /// Fetches the latest information about an existing Order.
         /// - Parameters:
-        ///   - order: an existing Order object to be updated.
+        ///   - order: an existing `AcmeOrderInfo` object to be updated.
         public func refresh(_ order: inout AcmeOrderInfo) async throws {
             try await self.client.ensureLoggedIn()
             
@@ -64,7 +65,7 @@ extension AcmeSwift {
         ///   - notBefore: Minimum Date when the future certificate will start being valid. **Note:** Let's Encrypt does not support setting this.
         ///   - notAfter: Desired expiration date of the future certificate. **Note:** Let's Encrypt does not support setting this.
         /// - Throws: Errors that can occur when executing the request.
-        /// - Returns: Returns  the `Account`.
+        /// - Returns: Returns  a new `AcmeOrderInfo`.
         public func create(domains: [String], notBefore: Date? = nil, notAfter: Date? = nil) async throws -> AcmeOrderInfo {
             try await self.client.ensureLoggedIn()
             
@@ -92,7 +93,7 @@ extension AcmeSwift {
         ///   - notBefore: Minimum Date when the future certificate will start being valid. **Note:** Let's Encrypt does not support setting this.
         ///   - notAfter: Desired expiration date of the future certificate. **Note:** Let's Encrypt does not support setting this.
         /// - Throws: Errors that can occur when executing the request.
-        /// - Returns: Returns  the `Account`.
+        /// - Returns: Returns  a new `AcmeOrderInfo`.
         public func create(permanentIdentifier: String, notBefore: Date? = nil, notAfter: Date? = nil) async throws -> AcmeOrderInfo {
             try await self.client.ensureLoggedIn()
 
@@ -104,6 +105,49 @@ extension AcmeSwift {
                     identifiers: identifiers,
                     notBefore: notBefore,
                     notAfter: notAfter
+                )
+            )
+
+            var (info, headers) = try await self.client.run(ep, privateKey: self.client.login!.key, accountURL: client.accountURL!)
+            info.url = URL(string: headers["Location"].first ?? "")
+            return info
+        }
+
+        /// Creates an Order to replace or renew an existing certificate.
+        /// This requires the ACMEv2 server to support the ACME Renewal Information (ARI) feature.
+        /// - Parameters:
+        ///   - certificate: The existing `X509.Certificate` to be renewed or replaced.
+        ///   - domains: If not set, the order will be created for the exact entries present in `certificate`.
+        ///
+        ///     If set, it will replace the entries present in `certificate` but at least one of them needs to be identical. Example: `["*.mydomain.com", "mydomain.com"]`.
+        ///   - notBefore: Minimum Date when the future certificate will start being valid. **Note:** Let's Encrypt does not support setting this.
+        ///   - notAfter: Desired expiration date of the future certificate. **Note:** Let's Encrypt does not support setting this.
+        /// - Throws: Errors that can occur when executing the request.
+        /// - Returns: Returns  a new `AcmeOrderInfo`.
+        public func replace(certificate: X509.Certificate, domains: [String]? = nil, notBefore: Date? = nil, notAfter: Date? = nil) async throws -> AcmeOrderInfo {
+            guard self.client.directory.renewalInfo != nil else {
+                throw AcmeError.unsupportedFeature(\.renewalInfo)
+            }
+
+            var domains = domains ?? []
+            if domains.count == 0, let sans = try certificate.extensions.subjectAlternativeNames {
+                for case let .dnsName(value) in sans {
+                    domains.append(value)
+                }
+            }
+
+            var identifiers: [AcmeOrderSpec.Identifier] = []
+            for domain in domains {
+                identifiers.append(.init(value: domain))
+            }
+
+            let ep = CreateOrderEndpoint(
+                directory: self.client.directory,
+                spec: .init(
+                    identifiers: identifiers,
+                    replaces: try certificate.getARICertId(),
+                    notBefore: notBefore,
+                    notAfter: notAfter,
                 )
             )
 

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
@@ -395,7 +395,7 @@ extension AcmeSwift {
         /// - Throws: Errors that can occur when executing the request.
         /// - Returns: Returns  a list of `AcmeAuthorization` containing the challenges that were not validated yet and may be in the process of being validated, or have failed.
         @discardableResult
-        public func validateChallenges(from order: AcmeOrderInfo, preferring: AcmeAuthorization.Challenge.ChallengeType? = nil, payload: Codable? = nil) async throws -> [AcmeAuthorization.Challenge] {
+        public func validateChallenges(from order: AcmeOrderInfo, preferring: AcmeAuthorization.Challenge.ChallengeType, payload: Codable? = nil) async throws -> [AcmeAuthorization.Challenge] {
             // get pending challenges
             let pendingChallenges = try await describePendingChallenges(from: order, preferring: preferring)
             var updatedChallenges: [AcmeAuthorization.Challenge] = []

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
@@ -295,6 +295,7 @@ extension AcmeSwift {
                         }
                         let digest = "\(token).\(accountThumbprint.base64URLString)"
                         let challengeDesc = ChallengeDescription(
+                            identifier: auth.identifier.value,
                             type: challenge.type,
                             endpoint: "_acme-challenge.\(auth.identifier.value)",
                             value: SHA256.hash(data: Array(digest.utf8)).base64URLString,
@@ -309,6 +310,7 @@ extension AcmeSwift {
                         }
                         let digest = "\(token).\(accountThumbprint.base64URLString)"
                         let challengeDesc = ChallengeDescription(
+                            identifier: auth.identifier.value,
                             type: challenge.type,
                             endpoint: "http://\(auth.identifier.value)/.well-known/acme-challenge/\(token)",
                             value: digest,
@@ -323,6 +325,7 @@ extension AcmeSwift {
                         }
                         let digest = "\(token).\(accountThumbprint.base64URLString)"
                         let challengeDesc = ChallengeDescription(
+                            identifier: auth.identifier.value,
                             type: challenge.type,
                             endpoint: "",
                             value: digest,
@@ -342,6 +345,7 @@ extension AcmeSwift {
                             digest += "; policy=wildcard"
                         }
                         let challengeDesc = ChallengeDescription(
+                            identifier: auth.identifier.value,
                             type: .dnsPersist,
                             endpoint: "_validation-persist.\(auth.identifier.value)",
                             value: digest,
@@ -357,6 +361,7 @@ extension AcmeSwift {
                         let accountHash = (Data(SHA256.hash(data: Array("\(client.accountURL!)".utf8)))[0...9]).base32String()
                         let digest = "\(token).\(accountThumbprint.base64URLString)"
                         let challengeDesc = ChallengeDescription(
+                            identifier: auth.identifier.value,
                             type: challenge.type,
                             endpoint: "_acme-challenge_\(accountHash).\(auth.identifier.value)",
                             value: SHA256.hash(data: Array(digest.utf8)).base64URLString,
@@ -368,7 +373,7 @@ extension AcmeSwift {
                     case .alpn:
                         continue
 
-                    default:
+                    @unknown default:
                         throw AcmeError.unsupportedChallenge(type: challenge.type)
                     }
                 }
@@ -412,8 +417,9 @@ extension AcmeSwift {
             let (updatedChallenge, _) = try await self.client.run(ep, privateKey: self.client.login!.key, accountURL: client.accountURL!)
             return updatedChallenge
         }
-        
-        private func validateChallenge(url: URL) async throws -> AcmeAuthorization.Challenge {
+
+        /// Validates a single challenge by its URL.
+        public func validateChallenge(url: URL) async throws -> AcmeAuthorization.Challenge {
             try await self.client.ensureLoggedIn()
             
             let ep = ValidateChallengeEndpoint(challengeURL: url)

--- a/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
+++ b/Sources/AcmeSwift/APIs/AcmeSwift+Orders.swift
@@ -156,6 +156,23 @@ extension AcmeSwift {
             return info
         }
 
+        /// Creates an Order to replace or renew an existing certificate.
+        /// This requires the ACMEv2 server to support the ACME Renewal Information (ARI) feature.
+        /// - Parameters:
+        ///   - pemEncoded: The existing certificate to be renewed or replaced, in PEM format..
+        ///   - domains: If not set, the order will be created for the exact entries present in `certificate`.
+        ///
+        ///     If set, it will replace the entries present in `certificate` but at least one of them needs to be identical. Example: `["*.mydomain.com", "mydomain.com"]`.
+        ///   - notBefore: Minimum Date when the future certificate will start being valid. **Note:** Let's Encrypt does not support setting this.
+        ///   - notAfter: Desired expiration date of the future certificate. **Note:** Let's Encrypt does not support setting this.
+        /// - Throws: Errors that can occur when executing the request.
+        /// - Returns: Returns  a new `AcmeOrderInfo`.
+        public func replace(pemEncoded: String, domains: [String]? = nil, notBefore: Date? = nil, notAfter: Date? = nil) async throws -> AcmeOrderInfo {
+            let x509 = try X509.Certificate(pemEncoded: pemEncoded)
+            return try await self.replace(certificate: x509)
+        }
+
+
         /// Creates the attestation payload used device-attest-01 challenges
         /// - Parameters:
         ///   - attObj: the base64url string with the WebAuthn attestation object.

--- a/Sources/AcmeSwift/Endpoints/Certificate/GetCertificateARIEndpoint.swift
+++ b/Sources/AcmeSwift/Endpoints/Certificate/GetCertificateARIEndpoint.swift
@@ -1,0 +1,14 @@
+import Foundation
+import NIOHTTP1
+
+struct GetCertificateARIEndpoint: EndpointProtocol {
+    var body: Body? = NoBody()
+    var method: HTTPMethod = .GET
+    typealias Response = AcmeCertificateRenewalInfo
+    typealias Body = NoBody
+    let url: URL
+
+    init(url: URL) {
+        self.url = url
+    }
+}

--- a/Sources/AcmeSwift/Helpers/Certificate+getARICertId.swift
+++ b/Sources/AcmeSwift/Helpers/Certificate+getARICertId.swift
@@ -1,0 +1,23 @@
+import Foundation
+import X509
+
+extension X509.Certificate {
+    // https://www.rfc-editor.org/rfc/rfc9773.html#section-4.1
+    func getARICertId() throws -> String {
+        guard let aki = try self.extensions.authorityKeyIdentifier?.keyIdentifier else {
+            throw AcmeError.missingAuthorityKeyIdentifier
+        }
+
+        // TODO: support older versions
+        guard #available(macOS 26.4, iOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *) else {
+            fatalError("swift too old")
+        }
+        let encodedAki = Data(aki)
+            .base64EncodedString(options: [.omitPaddingCharacter, .base64URLAlphabet])
+        let encodedSerial = Data(self.serialNumber.bytes)
+            .base64EncodedString(options: [.omitPaddingCharacter, .base64URLAlphabet])
+
+        let ariCertId = encodedAki + "." + encodedSerial
+        return ariCertId
+    }
+}

--- a/Sources/AcmeSwift/Helpers/Certificate+getARICertId.swift
+++ b/Sources/AcmeSwift/Helpers/Certificate+getARICertId.swift
@@ -8,16 +8,23 @@ extension X509.Certificate {
             throw AcmeError.missingAuthorityKeyIdentifier
         }
 
-        // TODO: support older versions
-        guard #available(macOS 26.4, iOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *) else {
-            fatalError("swift too old")
+        var ariCertId: String
+        if #available(macOS 26.4, iOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4, *) {
+            let encodedAki = Data(aki)
+                .base64EncodedString(options: [.omitPaddingCharacter, .base64URLAlphabet])
+            let encodedSerial = Data(self.serialNumber.bytes)
+                .base64EncodedString(options: [.omitPaddingCharacter, .base64URLAlphabet])
+            ariCertId = encodedAki + "." + encodedSerial
         }
-        let encodedAki = Data(aki)
-            .base64EncodedString(options: [.omitPaddingCharacter, .base64URLAlphabet])
-        let encodedSerial = Data(self.serialNumber.bytes)
-            .base64EncodedString(options: [.omitPaddingCharacter, .base64URLAlphabet])
-
-        let ariCertId = encodedAki + "." + encodedSerial
+        else {
+            let encodedAki = Data(aki)
+                .base64EncodedString()
+                .base64ToBase64Url()
+            let encodedSerial = Data(self.serialNumber.bytes)
+                .base64EncodedString()
+                .base64ToBase64Url()
+            ariCertId = encodedAki + "." + encodedSerial
+        }
         return ariCertId
     }
 }

--- a/Sources/AcmeSwift/Helpers/String+base64Url.swift
+++ b/Sources/AcmeSwift/Helpers/String+base64Url.swift
@@ -23,7 +23,8 @@ extension String {
             .base64EncodedString()
             .base64ToBase64Url()
     }
-    
+
+    // TODO: can be replaced with .base64EncodedString(options: [.omitPaddingCharacter, .base64URLAlphabet]) in Swift 6.4
     /// Converts a Base64 string to one suitable for use as URL parameters.
     @usableFromInline
     func base64ToBase64Url() -> String {

--- a/Sources/AcmeSwift/Models/AcmeDirectory.swift
+++ b/Sources/AcmeSwift/Models/AcmeDirectory.swift
@@ -10,6 +10,7 @@ public struct AcmeDirectory: Sendable {
     public let newOrder: URL
     public let revokeCert: URL
     public let keyChange: URL
+    public let renewalInfo: URL?
     public let meta: Meta?
     
     public struct Meta: Codable, Sendable {

--- a/Sources/AcmeSwift/Models/AcmeError.swift
+++ b/Sources/AcmeSwift/Models/AcmeError.swift
@@ -32,6 +32,12 @@ public enum AcmeError: Error, Sendable {
 
     /// Challenge requires a token but server didn't set any
     case missingChallengeToken
+
+    /// The ACME server's directory does not advertise support for this feature.
+    case unsupportedFeature(KeyPath<AcmeDirectory, URL?> & Sendable)
+
+    /// The Certificate has no AuthorityKeyIdentifier extension (can't check renewal info)
+    case missingAuthorityKeyIdentifier
 }
 
 public struct AcmeResponseError: Error, Sendable {
@@ -123,6 +129,9 @@ public struct AcmeResponseError: Error, Sendable {
         
         /// Visit the "instance" URL and take actions specified there
         case userActionRequired = "urn:ietf:params:acme:error:userActionRequired"
+
+        /// The request specified a predecessor certificate that has already been marked as replaced
+        case alreadyReplaced = "urn:ietf:params:acme:error:alreadyReplaced"
     }
     
     public struct ErrorIdentifier: Codable, Sendable {
@@ -131,6 +140,5 @@ public struct AcmeResponseError: Error, Sendable {
     }
 }
 
-extension AcmeError: Codable {}
 extension AcmeResponseError: Codable {}
 extension AcmeResponseError.AcmeErrorType: Codable {}

--- a/Sources/AcmeSwift/Models/Certificate/AcmeCertificateARIInformation.swift
+++ b/Sources/AcmeSwift/Models/Certificate/AcmeCertificateARIInformation.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Information about the recommended renewal window for a certificate.
+public struct AcmeCertificateRenewalInfo: Sendable {
+
+    /// The window of time in which the CA recommends renewing the certificate.
+    public let suggestedWindow: SuggestedRenewalWindow
+
+    /// A URL pointing to a page that may explain why the suggested renewal window has its current value.
+    public let explanationURL: URL?
+
+    /// Recommended amount of time (in seconds) after which this renewal info should be fetched again.
+    internal(set) public var nextCheck: TimeInterval? = nil
+
+    public struct SuggestedRenewalWindow: Sendable {
+        public let start: Date
+        public let end: Date
+    }
+}
+
+extension AcmeCertificateRenewalInfo: Codable {}
+extension AcmeCertificateRenewalInfo.SuggestedRenewalWindow: Codable {}

--- a/Sources/AcmeSwift/Models/Order/AcmeOrderInfo.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeOrderInfo.swift
@@ -28,7 +28,10 @@ public struct AcmeOrderInfo: Sendable {
     
     /// URL to call to obtain the certificate  when the Order has been finalized and has a `valid` status.
     public let certificate: URL?
-    
+
+    /// The ARI CertID if we're trying to renew a previous certificate.
+    public var replaces: String?
+
     
     public enum OrderStatus: String, Codable, Sendable {
         /// The certificate will not be issued. Consider this order process abandoned.

--- a/Sources/AcmeSwift/Models/Order/AcmeOrderInfo.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeOrderInfo.swift
@@ -30,7 +30,7 @@ public struct AcmeOrderInfo: Sendable {
     public let certificate: URL?
 
     /// The ARI CertID if we're trying to renew a previous certificate.
-    public var replaces: String?
+    public let replaces: String?
 
     
     public enum OrderStatus: String, Codable, Sendable {

--- a/Sources/AcmeSwift/Models/Order/AcmeOrderSpec.swift
+++ b/Sources/AcmeSwift/Models/Order/AcmeOrderSpec.swift
@@ -1,14 +1,18 @@
 import Foundation
 
 public struct AcmeOrderSpec: Sendable {
-    public init(identifiers: [AcmeOrderSpec.Identifier], notBefore: Date? = nil, notAfter: Date? = nil) {
+    public init(identifiers: [AcmeOrderSpec.Identifier], replaces: String? = nil, notBefore: Date? = nil, notAfter: Date? = nil) {
         self.identifiers = identifiers
         self.notBefore = notBefore
         self.notAfter = notAfter
+        self.replaces = replaces
     }
     
     public var identifiers: [Identifier]
-    
+
+    /// The ARI CertID if we're trying to renew a previous certificate.
+    public var replaces: String?
+
     /// The requested value of the notBefore field in the certificate.
     public var notBefore: Date? = nil
     

--- a/Sources/AcmeSwift/Models/Order/ChallengeDescription.swift
+++ b/Sources/AcmeSwift/Models/Order/ChallengeDescription.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 public struct ChallengeDescription: Sendable {
+    /// The identifier that is part of the certificate order for which we have a challenge.
+    public let identifier: String
+    
     /// The type of challenge.
     /// For a wildcard certificate, there will **always** be a at least one DNS challenge, even if your preferred method is HTTP.
     public let type: AcmeAuthorization.Challenge.ChallengeType
@@ -18,7 +21,7 @@ public struct ChallengeDescription: Sendable {
     public let token: String?
 
     /// The ACMEv2 server URL for validating this challenge
-    internal let url: URL
+    public let url: URL
 }
 
 extension ChallengeDescription: Codable {}

--- a/Tests/AcmeSwiftTests/OrderTests.swift
+++ b/Tests/AcmeSwiftTests/OrderTests.swift
@@ -116,6 +116,22 @@ final class OrderTests: XCTestCase {
             try certs.joined(separator: "\n").write(to: URL(fileURLWithPath: "cert.pem"), atomically: true, encoding: .utf8)
             
             try key.serializeAsPEM().pemString.write(to: URL(fileURLWithPath: "key.pem"), atomically: true, encoding: .utf8)
+
+            let renewalInfo = try await acme.certificates.getRenewalInfo(certificatePem: certs[0])
+            logger.info("Renewal Info: \(renewalInfo)")
+            let x509 = try Certificate(pemEncoded: certs[0])
+
+            var replaceOrder = try await acme.orders.replace(certificate: x509)
+            var replaceChallenges = try await acme.orders.validateChallenges(from: replaceOrder, preferring: .dnsPersist)
+            for timeout in [5, 10, 10, 10, 10, 30] {
+                guard !replaceChallenges.isEmpty else { break }
+                try await Task.sleep(for: .seconds(timeout))
+                replaceChallenges = try await acme.orders.validateChallenges(from: replaceOrder, preferring: .dnsPersist)
+            }
+            let replaceKey = try await acme.orders.finalize(order: &replaceOrder, type: .ecdsa(.p384))
+            let replaceCerts = try await acme.certificates.download(for: replaceOrder)
+            let replacedX509 = try Certificate(pemEncoded: replaceCerts[0])
+            logger.info("Renewed cert: \(replacedX509)")
         }
         catch(let error) {
             print("\n•••• BOOM! \(error)")


### PR DESCRIPTION
ARI: https://www.rfc-editor.org/rfc/rfc9773.html

This PR adds support for:
- Fetching ARI information, which gives a recommended window of time for renewing a certificate, and a recommended for refreshing the ARI info.
- Renewing a certificate by leveraging ARI; if we respect the recommended time window, the operation doesn't count against the Let'sEncrypt rate-limits 